### PR TITLE
fix: Pin tree-sitter version to 0.25

### DIFF
--- a/Formula/emacs-mac-exp@30.rb
+++ b/Formula/emacs-mac-exp@30.rb
@@ -46,7 +46,7 @@ class EmacsMacExpAT30 < Formula
   depends_on "texinfo"
   depends_on "librsvg" => :recommended
   depends_on "libxml2" => :recommended
-  depends_on "tree-sitter" => :recommended
+  depends_on "tree-sitter@0.25" => :recommended
   depends_on "dbus" => :optional
   depends_on "glib" => :optional
   depends_on "imagemagick" => :optional

--- a/Formula/emacs-mac-exp@31.rb
+++ b/Formula/emacs-mac-exp@31.rb
@@ -43,7 +43,7 @@ class EmacsMacExpAT31 < Formula
   depends_on "texinfo"
   depends_on "librsvg" => :recommended
   depends_on "libxml2" => :recommended
-  depends_on "tree-sitter" => :recommended
+  depends_on "tree-sitter@0.25" => :recommended
   depends_on "dbus" => :optional
   depends_on "glib" => :optional
   depends_on "imagemagick" => :optional


### PR DESCRIPTION
This will update the dependency on tree-sitter to 0.25 so subsequent builds of this formula will succeed until the upstream code is updated accordingly. 

fixes: https://github.com/pkryger/homebrew-emacsmacport-exp/issues/7